### PR TITLE
Add `servercom` library to make building voltlane servers easier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "servercom"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "net",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1010,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,6 @@ name = "connserver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "dotenvy",
  "enc",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["connserver", "enc", "net", "clientcom", "clientcom-c"]
+members = ["connserver", "enc", "net", "clientcom", "clientcom-c", "servercom"]
 resolver = "2"
 
 [profile.release-with-debug]

--- a/connserver/Cargo.toml
+++ b/connserver/Cargo.toml
@@ -14,7 +14,6 @@ enc = { path = "../enc" }
 anyhow = "1.0.98"
 serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.8.20"
-async-trait = "0.1.88"
 dotenvy = "0.15.7"
 
 [profile.release-with-debug]

--- a/connserver/src/master.rs
+++ b/connserver/src/master.rs
@@ -1,15 +1,16 @@
+use std::future::Future;
+
 use net::TaggedPacket;
 use tokio::net::{
     tcp::{OwnedReadHalf, OwnedWriteHalf},
     TcpStream,
 };
 
-#[async_trait::async_trait]
 pub trait MasterDuplex: Send + Sync {
     /// Send a tagged packet to the master.
-    async fn send_packet(&mut self, packet: TaggedPacket) -> anyhow::Result<()>;
+    fn send_packet(&mut self, packet: TaggedPacket) -> impl Future<Output = anyhow::Result<()>> + Send;
     /// Receive a tagged packet from the master.
-    async fn recv_packet(&mut self) -> anyhow::Result<TaggedPacket>;
+    fn recv_packet(&mut self) -> impl Future<Output = anyhow::Result<TaggedPacket>> + Send;
 }
 
 pub struct TcpMasterDuplex {
@@ -29,7 +30,6 @@ impl TcpMasterDuplex {
     }
 }
 
-#[async_trait::async_trait]
 impl MasterDuplex for TcpMasterDuplex {
     async fn send_packet(&mut self, packet: TaggedPacket) -> anyhow::Result<()> {
         net::send_tagged_packet(&mut self.write, packet).await

--- a/servercom/Cargo.toml
+++ b/servercom/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "servercom"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0.98"
+async-trait = "0.1.88"
+net = { path = "../net" }
+thiserror = "2.0.12"
+tokio = "1.44.2"

--- a/servercom/src/lib.rs
+++ b/servercom/src/lib.rs
@@ -1,0 +1,50 @@
+use async_trait::async_trait;
+use tokio::net::TcpStream;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+
+#[async_trait]
+pub trait MasterServer {
+    async fn handle_packet(
+        &mut self,
+        packet: net::TaggedPacket,
+        send_packet: impl AsyncFnMut(net::TaggedPacket) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()>;
+}
+
+pub struct ServerCore<Client, Master>
+where
+    Master: MasterServer,
+{
+    pub clients: Vec<Client>,
+    pub read: net::FramedReader<OwnedReadHalf>,
+    pub write: OwnedWriteHalf,
+    pub master: Master,
+}
+
+impl<ClientT, Master> ServerCore<ClientT, Master>
+where
+    Master: MasterServer,
+{
+    pub fn new(mut stream: TcpStream, master: Master) -> anyhow::Result<Self> {
+        net::configure_performance_tcp_socket(&mut stream)?;
+        let (read, write) = stream.into_split();
+        let read = net::new_framed_reader(read);
+        Ok(Self {
+            read,
+            write,
+            clients: Vec::new(),
+            master,
+        })
+    }
+
+    pub async fn run(&mut self) -> anyhow::Result<()> {
+        loop {
+            let packet = net::recv_tagged_packet(&mut self.read).await?;
+            self.master
+                .handle_packet(packet, async |packet| -> anyhow::Result<()> {
+                    net::send_tagged_packet(&mut self.write, packet).await
+                })
+                .await?;
+        }
+    }
+}

--- a/servercom/src/lib.rs
+++ b/servercom/src/lib.rs
@@ -1,14 +1,14 @@
-use async_trait::async_trait;
 use tokio::net::TcpStream;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use std::future::Future;
+use net;
 
-#[async_trait]
 pub trait MasterServer {
-    async fn handle_packet(
+    fn handle_packet(
         &mut self,
         packet: net::TaggedPacket,
         send_packet: impl AsyncFnMut(net::TaggedPacket) -> anyhow::Result<()>,
-    ) -> anyhow::Result<()>;
+    ) -> impl Future<Output = anyhow::Result<()>>;
 }
 
 pub struct ServerCore<Client, Master>


### PR DESCRIPTION
Adds a `servercom` module; used soon in voltchat as a demo.